### PR TITLE
Modified multiple level inheritance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ From 0.4.RELEASE, you can downlod this library from the maven central repository
 ### Gradle dependencies
 ```groovy
 dependencies {
-    compile 'kr.pe.kwonnam.freemarker:freemarker-template-inheritance:0.4.RELEASE'
+    compile 'io.github.matteosilv:freemarker-template-inheritance:0.6'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ dependencies {
 
 ```xml
 <dependency>
-    <groupId>kr.pe.kwonnam.freemarker</groupId>
+    <groupId>io.github.matteosilv</groupId>
     <artifactId>freemarker-template-inheritance</artifactId>
-    <version>0.4.RELEASE</version>
+    <version>0.6</version>
     <scope>compile</scope>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
     group = 'io.github.matteosilv.freemarker'
-    version = '0.5-SNAPSHOT'
+    version = '0.6'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+// The original source file has been modified by Matteo Silvestri 
+// <matteosilv@gmail.com> on date 2017-10-26
 subprojects {
     apply plugin: 'java'
 
@@ -9,7 +11,7 @@ subprojects {
     targetCompatibility = javaVersion
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-    group = 'kr.pe.kwonnam.freemarker'
+    group = 'io.github.matteosilv.freemarker'
     version = '0.5-SNAPSHOT'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     targetCompatibility = javaVersion
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-    group = 'io.github.matteosilv.freemarker'
+    group = 'io.github.matteosilv'
     version = '0.6'
 
     repositories {

--- a/freemarker-template-inheritance/build.gradle
+++ b/freemarker-template-inheritance/build.gradle
@@ -1,3 +1,5 @@
+// The original source file has been modified by Matteo Silvestri 
+// <matteosilv@gmail.com> on date 2017-10-26
 apply plugin: 'maven'
 apply plugin: 'signing'
 
@@ -48,11 +50,11 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
                     name "${project.name}"
                     packaging 'jar'
                     description 'Freemarker template inheritance.'
-                    url 'https://github.com/kwon37xi/freemarker-template-inheritance'
+                    url 'https://github.com/matteosilv/freemarker-template-inheritance'
 
                     scm {
-                        connection 'scm:git:https://github.com/kwon37xi/freemarker-template-inheritance.git'
-                        url 'https://github.com/kwon37xi/freemarker-template-inheritance'
+                        connection 'scm:git:https://github.com/matteosilv/freemarker-template-inheritance.git'
+                        url 'https://github.com/matteosilv/freemarker-template-inheritance'
                     }
 
                     licenses {
@@ -67,6 +69,11 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
                             id 'kwon37xi'
                             name 'KwonNam Son'
                             email 'kwon37xi@gmail.com'
+                        }
+                        developer {
+                            id 'matteosilv'
+                            name 'Matteo Silvestri'
+                            email 'matteosilv@gmail.com'
                         }
                     }
                 }

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/Block.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/Block.java
@@ -1,0 +1,33 @@
+package kr.pe.kwonnam.freemarker.inheritance;
+
+/**
+ * Block.
+ * 
+ * User: Matteo Silvestri(matteosilv@gmail.com}
+ * Date: 17. 10. 26
+ * Time: 오전 10:38
+ */
+public class Block {
+
+    private final String name;
+    private final PutType type;
+    private final String content;
+
+    public String getName() {
+        return name;
+    }
+
+    public PutType getType() {
+        return type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Block(String name, PutType type, String content) {
+        this.name = name;
+        this.type = type;
+        this.content = content;
+    }
+}

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirective.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirective.java
@@ -1,13 +1,18 @@
 package kr.pe.kwonnam.freemarker.inheritance;
 
-import freemarker.core.Environment;
-import freemarker.template.*;
+import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.*;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
 
-import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.*;
+import freemarker.core.Environment;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
 
 /**
  * User: KwonNam Son(kwon37xi@gmail.com}
@@ -21,31 +26,30 @@ public class BlockDirective implements TemplateDirectiveModel {
     @Override
     public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body) throws TemplateException, IOException {
         String blockName = getBlockName(env, params, BLOCK_NAME_PARAMETER);
-        PutType putType = getPutType(env, blockName);
+        BlockStack blockStack = getBlockStack(env, blockName);
+        
         String bodyResult = getBodyResult(body);
 
+        while (!blockStack.isEmpty()) {
+            StringWriter writer = new StringWriter();
+            Block block = blockStack.pop();
+            block.getType()
+                    .write(writer, 
+                           bodyResult,
+                           block.getContent());
+            bodyResult = writer.toString();
+        }
+
         Writer out = env.getOut();
-
-        String putContents = getPutContents(env, blockName);
-
-        putType.write(out, bodyResult, putContents);
+        out.write(bodyResult);
     }
 
-    private PutType getPutType(Environment env, String blockName) throws TemplateException {
-        SimpleScalar putTypeScalar = (SimpleScalar) env.getVariable(getBlockTypeVarName(blockName));
-        if (putTypeScalar == null) {
-            return PutType.APPEND;
+    private BlockStack getBlockStack(Environment env, String blockName) throws TemplateModelException {
+        BlockStack blockStack = (BlockStack) env.getVariable(getBlockVarName(blockName));
+        if (blockStack == null) {
+            blockStack = new BlockStack();
         }
-
-        return PutType.valueOf(putTypeScalar.getAsString());
+        return blockStack;
     }
 
-    private String getPutContents(Environment env, String blockName) throws TemplateModelException {
-        SimpleScalar putContentsModel = (SimpleScalar) env.getVariable(getBlockContentsVarName(blockName));
-        String putContents = "";
-        if (putContentsModel != null) {
-            putContents = putContentsModel.getAsString();
-        }
-        return putContents;
-    }
 }

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirective.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirective.java
@@ -1,3 +1,7 @@
+/* 
+ * The original source file has been modified by Matteo Silvestri 
+ * <matteosilv@gmail.com> on date 2017-10-26
+ */
 package kr.pe.kwonnam.freemarker.inheritance;
 
 import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.*;

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirectiveUtils.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirectiveUtils.java
@@ -1,3 +1,7 @@
+/* 
+ * The original source file has been modified by Matteo Silvestri 
+ * <matteosilv@gmail.com> on date 2017-10-26
+ */
 package kr.pe.kwonnam.freemarker.inheritance;
 
 import freemarker.core.Environment;

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirectiveUtils.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockDirectiveUtils.java
@@ -25,12 +25,8 @@ public class BlockDirectiveUtils {
         return writer.toString();
     }
 
-    public static String getBlockContentsVarName(String blockName) {
-        return PutDirective.PUT_DATA_PREFIX + blockName + ".contents";
-    }
-
-    public static String getBlockTypeVarName(String blockName) {
-        return PutDirective.PUT_DATA_PREFIX + blockName + ".type";
+    public static String getBlockVarName(String blockName) {
+        return PutDirective.PUT_DATA_PREFIX + blockName;
     }
 
     public static String getBlockName(Environment env, Map params, String paramName) throws TemplateException {

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockStack.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/BlockStack.java
@@ -1,0 +1,18 @@
+package kr.pe.kwonnam.freemarker.inheritance;
+
+import java.util.Stack;
+
+import freemarker.template.TemplateModel;
+
+/**
+ * Stack of {@link Block} objects.
+ * 
+ * User: Matteo Silvestri(matteosilv@gmail.com}
+ * Date: 17. 10. 26
+ * Time: 오전 10:38
+ */
+public class BlockStack extends Stack<Block> implements TemplateModel {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/PutDirective.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/PutDirective.java
@@ -1,3 +1,7 @@
+/* 
+ * The original source file has been modified by Matteo Silvestri 
+ * <matteosilv@gmail.com> on date 2017-10-26
+ */
 package kr.pe.kwonnam.freemarker.inheritance;
 
 import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.getBlockName;

--- a/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/PutDirective.java
+++ b/freemarker-template-inheritance/src/main/java/kr/pe/kwonnam/freemarker/inheritance/PutDirective.java
@@ -1,12 +1,18 @@
 package kr.pe.kwonnam.freemarker.inheritance;
 
-import freemarker.core.Environment;
-import freemarker.template.*;
+import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.getBlockName;
+import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.getBlockVarName;
+import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.getBodyResult;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static kr.pe.kwonnam.freemarker.inheritance.BlockDirectiveUtils.*;
+import freemarker.core.Environment;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
 
 /**
  * User: KwonNam Son(kwon37xi@gmail.com}
@@ -24,8 +30,15 @@ public class PutDirective implements TemplateDirectiveModel {
         PutType putType = getPutType(params);
         String bodyResult = getBodyResult(body);
 
-        env.setVariable(getBlockContentsVarName(blockName), new SimpleScalar(bodyResult));
-        env.setVariable(getBlockTypeVarName(blockName), new SimpleScalar(putType.name()));
+        Block block = new Block(blockName, putType, bodyResult);
+
+        String blockVarName = getBlockVarName(blockName);
+        BlockStack blockStack = (BlockStack) env.getVariable(blockVarName);
+        if (blockStack == null) {
+            blockStack = new BlockStack();
+            env.setVariable(blockVarName, blockStack);
+        }
+        blockStack.push(block);
     }
 
     private PutType getPutType(Map params) {

--- a/freemarker-template-inheritance/src/test/java/kr/pe/kwonnam/freemarker/inheritance/ExtendsManyTimesTest.java
+++ b/freemarker-template-inheritance/src/test/java/kr/pe/kwonnam/freemarker/inheritance/ExtendsManyTimesTest.java
@@ -1,3 +1,7 @@
+/* 
+ * The original source file has been modified by Matteo Silvestri 
+ * <matteosilv@gmail.com> on date 2017-10-26
+ */
 package kr.pe.kwonnam.freemarker.inheritance;
 
 import org.junit.Test;

--- a/freemarker-template-inheritance/src/test/java/kr/pe/kwonnam/freemarker/inheritance/ExtendsManyTimesTest.java
+++ b/freemarker-template-inheritance/src/test/java/kr/pe/kwonnam/freemarker/inheritance/ExtendsManyTimesTest.java
@@ -17,8 +17,8 @@ public class ExtendsManyTimesTest extends AbstractDirectiveTest {
         String result = processTemplate("extends_many_times.ftl");
 
         assertThat("다차 상속", result, is("{[FirstBlock-FirstBlockChild1-FirstAppendBlockChild2]" +
-                "[SecondBlock-SecondBlockChildReplace]" +
-                "[ThirdBlock-ThirdBlockChildPrepend2-ThirdBlockChild1]" +
+                "[SecondBlockChildReplace]" +
+                "[ThirdBlockChildPrepend2-ThirdBlock-ThirdBlockChild1]" +
                 "[FourthBlock-FourthBlockChildAppend2]" +
                 "[FifthBlock-FifthBlockChild1]}"));
     }

--- a/freemarker-template-inheritance/src/test/java/kr/pe/kwonnam/freemarker/inheritance/ExtendsManyTimesWithBlockTest.java
+++ b/freemarker-template-inheritance/src/test/java/kr/pe/kwonnam/freemarker/inheritance/ExtendsManyTimesWithBlockTest.java
@@ -1,0 +1,25 @@
+package kr.pe.kwonnam.freemarker.inheritance;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * User: KwonNam Son(kwon37xi@gmail.com}
+ * Date: 13. 6. 30
+ * Time: 오후 11:43
+ */
+public class ExtendsManyTimesWithBlockTest extends AbstractDirectiveTest {
+
+    @Test
+    public void extends_many_times_with_block() {
+        String result = processTemplate("extends_many_times_with_block.ftl");
+
+        assertThat("다차 상속", result, is("{[FirstBlock-FirstBlockChild1-FirstAppendBlockChild2]" +
+                "[SecondBlock-SecondBlockChildReplace]" +
+                "[ThirdBlock-ThirdBlockChildPrepend2-ThirdBlockChild1]" +
+                "[FourthBlock-FourthBlockChildAppend2]" +
+                "[FifthBlock-FifthBlockChild1]}"));
+    }
+}

--- a/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/extends_many_times_with_block.ftl
+++ b/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/extends_many_times_with_block.ftl
@@ -1,0 +1,6 @@
+<@layout.extends name="/layouts/extends_many_times_middle_with_block.ftl">
+    <@layout.put block="first" type="append">FirstAppendBlockChild2</@layout.put>
+    <@layout.put block="second" type="replace">SecondBlockChildReplace</@layout.put>
+    <@layout.put block="third" type="prepend">ThirdBlockChildPrepend2-</@layout.put>
+    <@layout.put block="fourth" type="append">FourthBlockChildAppend2</@layout.put>
+</@layout.extends>

--- a/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/layouts/extends_many_times_middle.ftl
+++ b/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/layouts/extends_many_times_middle.ftl
@@ -1,6 +1,6 @@
 <@layout.extends name="/layouts/extends_many_times_base.ftl">
-    <@layout.put block="first"><@layout.block name="first">FirstBlockChild1-</@layout.block></@layout.put>
-    <@layout.put block="second"><@layout.block name="second">SecondBlock will not shown</@layout.block></@layout.put>
-    <@layout.put block="third"><@layout.block name="third">ThirdBlockChild1</@layout.block></@layout.put>
+    <@layout.put block="first">FirstBlockChild1-</@layout.put>
+    <@layout.put block="second">SecondBlock will not shown</@layout.put>
+    <@layout.put block="third">ThirdBlockChild1</@layout.put>
     <@layout.put block="fifth">FifthBlockChild1</@layout.put>
 </@layout.extends>

--- a/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/layouts/extends_many_times_middle.ftl
+++ b/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/layouts/extends_many_times_middle.ftl
@@ -1,3 +1,7 @@
+<#-- 
+ The original source file has been modified by Matteo Silvestri 
+ <matteosilv@gmail.com> on date 2017-10-26
+ -->
 <@layout.extends name="/layouts/extends_many_times_base.ftl">
     <@layout.put block="first">FirstBlockChild1-</@layout.put>
     <@layout.put block="second">SecondBlock will not shown</@layout.put>

--- a/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/layouts/extends_many_times_middle_with_block.ftl
+++ b/freemarker-template-inheritance/src/test/resources/kr/pe/kwonnam/freemarker/inheritance/layouts/extends_many_times_middle_with_block.ftl
@@ -1,0 +1,6 @@
+<@layout.extends name="/layouts/extends_many_times_base.ftl">
+    <@layout.put block="first"><@layout.block name="first">FirstBlockChild1-</@layout.block></@layout.put>
+    <@layout.put block="second"><@layout.block name="second">SecondBlock will not shown</@layout.block></@layout.put>
+    <@layout.put block="third"><@layout.block name="third">ThirdBlockChild1</@layout.block></@layout.put>
+    <@layout.put block="fifth">FifthBlockChild1</@layout.put>
+</@layout.extends>


### PR DESCRIPTION
Now for multiple level inheritance it is not required anymore to 
redefine the block.

The previous behaviour is still supported. The test still succeed and have been moved to the file `ExtendsManyTimesWithBlockTest.java`.

The new behaviour puts the override operations on a stack and execute them in reverse order from the base template.